### PR TITLE
Render research page from a TOML data file

### DIFF
--- a/content/research.md
+++ b/content/research.md
@@ -8,72 +8,18 @@ hide_title = true
 
 ## Selected Publications
 
-See [google scholar](https://scholar.google.com/citations?hl=en&user=7nqnc34AAAAJ) for a full list.
+See [google scholar](https://scholar.google.com/citations?hl=en&user=7nqnc34AAAAJ) for a full updated list.
 
-- [Parameterising the effect of a continuous treatment using average derivative effects.](https://doi.org/10.1093/biomet/asag012)\
-Hines, O. J., Diaz-Ordaz, K., \& Vansteelandt, S.\
-Biometrika, 2026.
-
-- [Variable importance measures for heterogeneous causal effects.](https://doi.org/10.1093/biomtc/ujaf140)\
-Hines, O. J., Diaz-Ordaz, K., \& Vansteelandt, S.\
-Biometrics, 2025.
-
-- [Automatic debiasing of neural networks via moment-constrained learning.](https://proceedings.mlr.press/v275/hines25a.html)\
-Hines, C. L., \& Hines, O. J.\
-Proceedings of the Fourth Conference on Causal Learning and Reasoning, PMLR, 2025.
-
-- [Demystifying statistical learning based on efficient influence functions.](https://doi.org/10.1080/00031305.2021.2021984)\
-Hines, O., Dukes, O., Diaz-Ordaz, K., \& Vansteelandt, S.\
-The American Statistician, 2022.
-
-- [Robust inference for mediated effects in partially linear models.](https://doi.org/10.1007/s11336-021-09768-z)\
-Hines, O., Vansteelandt, S., \& Diaz-Ordaz, K.\
-Psychometrika, 2021.
-
-- [Causal graphs for the analysis of genetic cohort data.](https://doi.org/10.1152/physiolgenomics.00115.2019)\
-Hines, O., Diaz-Ordaz, K., Vansteelandt, S., \& Jamshidi, Y.\
-Physiological Genomics, 2020.
+{{ papers(kind="article") }}
 
 ## Preprints
 
-- [Learning density ratios in causal inference using Bregman-Riesz regression](https://doi.org/10.48550/arXiv.2510.16127)\
-Hines O.J. \& Miles C.H.
-Arxiv, 2025.
+{{ papers(kind="preprint") }}
 
-## Presentations and workshops
+## Talks
 
-- *Variable importance measures for heterogeneous treatment effects*. Joint Statistical Meeting (Nashville, USA), August 2025
-
-- *Causal inference with continuous treatments, a tale of two estimands*. Symposium organised by the Centre for Microdata Methods and Practice (London, UK), December 2023.
-
-- *Bridging the divide: data science and statistics in academia and industry*. Invited Ghent University Seminar (Ghent, Belgium), October 2023.
-
-- *Demystifying statistical learning based on efficient influence functions*.  CMStatistics (London, UK) December 2022.
-
-- *Variable importance measures for heterogeneous causal effects*.  International Biometric Conference (Riga, Latvia) July 2022.
-
-- *Assumption-lean causal inference for direct and indirect effects*. Joint Statistical Meeting (virtual) August 2021.
-
-- *Parameterising and inferring the effect of a continuous exposure using average derivative effects*. European Causal Inference Meeting (virtual), May 2021.
-
-- *Causal machine learning workshop*. European Causal Inference Meeting (virtual), May 2021.
+{{ presentations() }}
 
 ## Peer review service
 
-- American Journal of Epidemiology
-
-- Biometrics
-
-- Biostatistics
-
-- International Journal of Biostatistics
-
-- Journal of the American Statistical Association
-
-- Journal of the Royal Statistical Society: Series A
-
-- Journal of the Royal Statistical Society: Series B
-
-- Scandinavian Journal of Statistics
-
-- Statistica Sinica
+{{ peer_review() }}

--- a/data/research.toml
+++ b/data/research.toml
@@ -1,0 +1,239 @@
+# Publications data.
+# Each entry's TOML array name controls which section it appears in on the
+# research page. Within each section, entries are sorted by year (descending).
+#
+# Set `hidden = true` on any entry to keep it in the file but exclude it from
+# the rendered page. Useful for staging non-"selected" papers — flipping the
+# flag becomes a one-line PR when you decide to surface them.
+#
+# Schema:
+#   article / preprint
+#     title    (string, required)
+#     authors  (list of strings, required)
+#     venue    (string, required) -- journal or proceedings
+#     year     (integer, required)
+#     url      (string, optional) -- DOI or canonical link
+#     hidden   (bool, optional) -- omit from rendered page
+#
+#   presentation
+#     title     (string, required)
+#     venue     (string, required)
+#     location  (string, optional)
+#     year      (integer, required)
+#     month     (string, optional) -- full month name e.g. "August"; used to sort within year
+#     invited   (bool, optional)
+#     hidden    (bool, optional) -- omit from rendered page
+#
+#   peer_review
+#     journal   (string, required)
+
+[[article]]
+title = "ScoreStop: Gradient-based early stopping using functional score tests"
+authors = ["Hines, O.J.", "Hines C.L."]
+venue = "ICML Workshop on Hypothesis Testing"
+year = 2026
+
+[[article]]
+title = "Parameterising the effect of a continuous treatment using average derivative effects"
+authors = ["Hines, O.J.", "Diaz-Ordaz, K.", "Vansteelandt, S."]
+venue = "Biometrika"
+year = 2026
+url = "https://doi.org/10.1093/biomet/asag012"
+
+[[article]]
+title = "Riesz representers for the rest of us"
+authors = ["Williams, N.T.", "Hines, O.J.", "Rudolph, K.E."]
+venue = "Epidemiology"
+year = 2026
+url = "https://doi.org/10.1097/EDE.0000000000001996"
+
+[[article]]
+title = "Variable importance measures for heterogeneous causal effects"
+authors = ["Hines, O.J.", "Diaz-Ordaz, K.", "Vansteelandt, S."]
+venue = "Biometrics"
+year = 2025
+url = "https://doi.org/10.1093/biomtc/ujaf140"
+
+[[article]]
+title = "Automatic debiasing of neural networks via moment-constrained learning"
+authors = ["Hines, C.L.", "Hines, O.J."]
+venue = "Proceedings of the Fourth Conference on Causal Learning and Reasoning, PMLR"
+year = 2025
+url = "https://proceedings.mlr.press/v275/hines25a.html"
+
+[[article]]
+title = "Demystifying statistical learning based on efficient influence functions"
+authors = ["Hines, O.J.", "Dukes, O.", "Diaz-Ordaz, K.", "Vansteelandt, S."]
+venue = "The American Statistician"
+year = 2022
+url = "https://doi.org/10.1080/00031305.2021.2021984"
+
+[[article]]
+hidden = true
+title = "Genetic analyses of the electrocardiographic QT interval and its components identify additional loci and pathways"
+authors = ["Young, W.J. et al."]
+venue = "Nature Communications"
+year = 2022
+url = "https://doi.org/10.1038/s41467-022-32821-z"
+
+[[article]]
+title = "Long-term cardiovascular outcomes after orlistat therapy in patients with obesity: a nationwide, propensity-score matched cohort study"
+authors = ["Ardissino, M.", "Vincent, M.", "Hines, O.J.", "Amin, R.", "Eichhorn, C.", "Tang, A.R.", "Collins, P.", "Moussa, O.", "Purkayastha, S."]
+venue = "European Heart Journal - Cardiovascular Pharmacotherapy"
+year = 2021
+url = "https://doi.org/10.1093/ehjcvp/pvaa133"
+
+[[article]]
+title = "Robust inference for mediated effects in partially linear models"
+authors = ["Hines, O.J.", "Vansteelandt, S.", "Diaz-Ordaz, K."]
+venue = "Psychometrika"
+year = 2021
+url = "https://doi.org/10.1007/s11336-021-09768-z"
+
+[[article]]
+title = "Causal graphs for the analysis of genetic cohort data"
+authors = ["Hines, O.J.", "Diaz-Ordaz, K.", "Vansteelandt, S.", "Jamshidi, Y."]
+venue = "Physiological Genomics"
+year = 2020
+url = "https://doi.org/10.1152/physiolgenomics.00115.2019"
+
+[[preprint]]
+title = "Learning density ratios in causal inference using Bregman-Riesz regression"
+authors = ["Hines, O. J.", "Miles, C. H."]
+venue = "Arxiv"
+year = 2025
+url = "https://doi.org/10.48550/arXiv.2510.16127"
+
+[[presentation]]
+title = "Learning density ratios in causal inference using Bregman-Riesz regression"
+venue = "International Symposium on Nonparametric Statistics"
+location = "Thessaloniki, Greece"
+invited = true
+month = "June"
+year = 2026
+
+[[presentation]]
+title = "Where best to intervene?"
+venue = "New England Statistics Symposium"
+location = "Storrs, CT, USA"
+invited = true
+month = "May"
+year = 2026
+
+[[presentation]]
+title = "Learning density ratios in causal inference using Bregman-Riesz regression"
+venue = "American Causal Inference Conference"
+location = "Salt Lake City UT, USA"
+invited = true
+month = "May"
+year = 2026
+
+[[presentation]]
+title = "Beyond the Dose–Response Curve: Weighted Average Derivative Effects for Continuous Treatments"
+venue = "University of Washington Seminar"
+invited = true
+location = "Seattle WA, USA"
+month = "March"
+year = 2026
+
+[[presentation]]
+title = "Variable importance measures for heterogeneous treatment effects"
+venue = "Joint Statistical Meeting"
+invited = true
+location = "Nashville TN, USA"
+month = "August"
+year = 2025
+
+[[presentation]]
+title = "What is Automatic Debiasing? Why do it and how?"
+venue = "Columbia University Seminar"
+invited = true
+location = "New York NY, USA"
+month = "April"
+year = 2025
+
+[[presentation]]
+title = "Causal inference with continuous treatments, a tale of two estimands"
+venue = "Symposium organised by the Centre for Microdata Methods and Practice"
+invited = true
+location = "London, UK"
+month = "December"
+year = 2023
+
+[[presentation]]
+title = "Bridging the divide: data science and statistics in academia and industry"
+venue = "Ghent University Seminar"
+invited = true
+location = "Ghent, Belgium"
+month = "October"
+year = 2023
+
+[[presentation]]
+title = "Demystifying statistical learning based on efficient influence functions"
+venue = "CMStatistics"
+invited = true
+location = "London, UK"
+month = "December"
+year = 2022
+
+[[presentation]]
+title = "Variable importance measures for heterogeneous causal effects"
+venue = "International Biometric Conference"
+location = "Riga, Latvia"
+month = "July"
+year = 2022
+
+[[presentation]]
+title = "Assumption-lean causal inference for direct and indirect effects"
+venue = "Joint Statistical Meeting"
+location = "virtual"
+month = "August"
+year = 2021
+
+[[presentation]]
+title = "Parameterising and inferring the effect of a continuous exposure using average derivative effects"
+venue = "European Causal Inference Meeting"
+invited = true
+location = "virtual"
+month = "May"
+year = 2021
+
+[[presentation]]
+title = "Causal machine learning workshop"
+venue = "European Causal Inference Meeting"
+location = "virtual"
+month = "May"
+year = 2021
+
+[[peer_review]]
+journal = "American Journal of Epidemiology"
+
+[[peer_review]]
+journal = "Biometrics"
+
+[[peer_review]]
+journal = "Biostatistics"
+
+[[peer_review]]
+journal = "International Conference on Machine Learning"
+
+[[peer_review]]
+journal = "International Journal of Biostatistics"
+
+[[peer_review]]
+journal = "Journal of the American Statistical Association"
+
+[[peer_review]]
+journal = "Journal of Causal Inference"
+
+[[peer_review]]
+journal = "Journal of the Royal Statistical Society: Series A"
+
+[[peer_review]]
+journal = "Journal of the Royal Statistical Society: Series B"
+
+[[peer_review]]
+journal = "Scandinavian Journal of Statistics"
+
+[[peer_review]]
+journal = "Statistica Sinica"

--- a/sass/style.sass
+++ b/sass/style.sass
@@ -240,3 +240,40 @@ hr
             color: $body-text
             & a
                 color: $body-text
+    & table.publications
+        width: 100%
+        border-collapse: collapse
+        margin: 1rem 0
+        & td, th
+            border: none
+            padding: 0.6rem 0
+            text-align: left
+            vertical-align: top
+        & .pub-year
+            width: 4rem
+            padding-right: 1rem
+            opacity: 0.55
+            font-variant-numeric: tabular-nums
+            line-height: 1.5
+        & .pub-entry
+            letter-spacing: 0.3px
+            line-height: 1.5
+            & .pub-title
+                display: block
+                & a
+                    border-bottom: none
+                    &:hover
+                        color: $links-hover
+            & .pub-authors
+                display: block
+                font-size: 0.95rem
+                opacity: 0.85
+            & .pub-venue
+                display: block
+                font-size: 0.95rem
+                opacity: 0.75
+    & .peer-review
+        margin-bottom: 1em
+        & .journal
+            line-height: 1.8
+            margin-bottom: 0

--- a/templates/shortcodes/papers.html
+++ b/templates/shortcodes/papers.html
@@ -1,0 +1,42 @@
+{# Render articles or preprints with year in a left-side column.
+   Years are sorted descending; within each year, entries are rendered
+   in the order they appear in publications.toml.
+   Usage: {{ papers(kind="article") }} #}
+{%- set data = load_data(path="data/research.toml") -%}
+{%- set items = data[kind] -%}
+{%- set_global years = [] -%}
+{%- for item in items -%}
+  {%- if item.year not in years -%}
+    {%- set_global years = years | concat(with=item.year) -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- set years = years | sort | reverse -%}
+<table class="publications">
+{%- for year in years -%}
+  {%- for item in items -%}
+    {%- if item.year == year and not item.hidden %}
+  <tr>
+    <td class="pub-year">{{ item.year }}</td>
+    <td class="pub-entry">
+      <span class="pub-title">
+        {%- if item.url -%}
+          <a href="{{ item.url }}">{{ item.title }}</a>
+        {%- else -%}
+          {{ item.title }}
+        {%- endif -%}
+      </span>
+      <span class="pub-authors">
+        {%- set n = item.authors | length -%}
+        {%- for a in item.authors -%}
+          {%- if loop.last and n > 1 -%}&amp; {{ a }}
+          {%- elif loop.last -%}{{ a }}
+          {%- else -%}{{ a }}, {% endif -%}
+        {%- endfor -%}
+      </span>
+      <span class="pub-venue"><em>{{ item.venue }}</em></span>
+    </td>
+  </tr>
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor %}
+</table>

--- a/templates/shortcodes/peer_review.html
+++ b/templates/shortcodes/peer_review.html
@@ -1,0 +1,9 @@
+{# Render peer-review service list, one journal per line.
+   Usage: {{ peer_review() }} #}
+{%- set data = load_data(path="data/research.toml") -%}
+{%- set items = data.peer_review | sort(attribute="journal") -%}
+<div class="peer-review">
+{%- for item in items %}
+  <div class="journal">{{ item.journal }}</div>
+{%- endfor %}
+</div>

--- a/templates/shortcodes/presentations.html
+++ b/templates/shortcodes/presentations.html
@@ -1,0 +1,48 @@
+{# Render presentations with year in a left-side column.
+   Years are sorted descending; within each year, entries are sorted by
+   month (descending). Entries without a month sort last for that year.
+   Usage: {{ presentations() }} #}
+{%- set data = load_data(path="data/research.toml") -%}
+{%- set items = data.presentation -%}
+{%- set month_order = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] -%}
+{%- set_global years = [] -%}
+{%- for item in items -%}
+  {%- if item.year not in years -%}
+    {%- set_global years = years | concat(with=item.year) -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- set years = years | sort | reverse -%}
+<table class="publications">
+{%- for year in years -%}
+  {%- for month in month_order | reverse -%}
+    {%- for item in items -%}
+      {%- if item.year == year and item.month == month and not item.hidden %}
+  <tr>
+    <td class="pub-year">{{ item.year }}</td>
+    <td class="pub-entry">
+      <span class="pub-title">{{ item.title }}</span>
+      <span class="pub-venue">
+        <em>{{- item.venue -}}</em>
+        {%- if item.location %} ({{ item.location }}){% endif -%}
+      </span>
+    </td>
+  </tr>
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endfor -%}
+  {%- for item in items -%}
+    {%- if item.year == year and not item.month and not item.hidden %}
+  <tr>
+    <td class="pub-year">{{ item.year }}</td>
+    <td class="pub-entry">
+      <span class="pub-title">{{ item.title }}</span>
+      <span class="pub-venue">
+        <em>{{- item.venue -}}</em>
+        {%- if item.location %} ({{ item.location }}){% endif -%}
+      </span>
+    </td>
+  </tr>
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor %}
+</table>


### PR DESCRIPTION
## Summary
- Moves publication entries (articles, preprints, presentations, peer review service) into `data/research.toml` as structured TOML.
- Adds three Tera shortcodes (`papers`, `presentations`, `peer_review`) that render the data with year as a side-column and title above smaller author and venue lines.
- Adds CSS for the new `.publications` table layout and `.peer-review` list.
- Supports a `hidden = true` flag per entry to stage non-"selected" papers without deleting them — surfacing one becomes a one-line PR.

Within each section, years are sorted descending; within a year, articles render in file order while presentations sort by month (descending).

## Test plan
- [ ] Visit `/research/` and confirm the page renders with year-on-the-left layout for publications, preprints, and presentations.
- [ ] Confirm peer review service journals appear alphabetically.
- [ ] Check that adding a new `[[article]]` entry to `data/research.toml` surfaces correctly without other edits.
- [ ] Toggle a `hidden = true` flag on any entry and confirm it disappears from the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)